### PR TITLE
Support closure compiler advanced optomisations

### DIFF
--- a/src/qajax.js
+++ b/src/qajax.js
@@ -3,17 +3,14 @@
  */
 /*jslint newcap: true */
 (function (definition) {
-  var Q;
   if (typeof exports === "object") {
-    Q = require("q");
-    module.exports = definition(Q);
+    module.exports = definition(require("q"));
   }
   else if (typeof define === 'function' && define.amd){
     define(['q'], definition);
   }
   else {
-    Q = window.Q;
-    window.Qajax = definition(Q);
+    Qajax = definition(Q);
   }
 })(function (Q) {
   "use strict";


### PR DESCRIPTION
Use the same implicit global export as q.js for the non-module case so that
closure can do renaming on qajax when included in a compile.

The existing code gets renamed in a way that ends up breaking things.
